### PR TITLE
Support BYOB ReadableStream

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "whatwg-url": "^5.0.0"
   },
   "dependencies": {
-    "web-streams-polyfill": "^1.3.2"
+    "@mattiasbuelens/web-streams-polyfill": "^0.2.0"
   },
   "peerDependencies": {
     "form-data": ">= 2.1.0"

--- a/src/body.js
+++ b/src/body.js
@@ -5,7 +5,7 @@
  * Body interface provides common methods for Request and Response
  */
 
-import { ReadableStream, TransformStream} from "web-streams-polyfill";
+import { ReadableStream, TransformStream} from "@mattiasbuelens/web-streams-polyfill/ponyfill/es6";
 
 import Blob, { BUFFER } from './blob.js';
 import FetchError from './fetch-error.js';
@@ -58,13 +58,20 @@ function readableNodeToWeb(nodeStream, instance) {
 				// TODO: Should we only do Buffer.from() if chunk is a UInt8Array?
 				// Potentially it makes more sense for down-stream consumers of fetch to cast to Buffer, instead?
 				// if(isUInt8Array(chunk)) {
-				controller.enqueue(Buffer.from(chunk));
+				controller.enqueue(new Uint8Array(Buffer.from(chunk)));
 
 				// HELP WANTED: The node-web-streams package pauses the nodeStream here, however,
 				// if we do that, then it gets permanently paused. Why?
                 // 		nodeStream.pause();
             });
-            nodeStream.on('end', () => controller.close());
+            nodeStream.on('end', () => {
+				controller.close();
+
+				const pending = controller.byobRequest;
+				if (pending) {
+					pending.respond(0);
+				}
+			});
             nodeStream.on('error', (err) => {
 				controller.error(new FetchError(`Invalid response body while trying to fetch ${instance.url}: ${err.message}`, 'system', err))
 			});
@@ -74,7 +81,8 @@ function readableNodeToWeb(nodeStream, instance) {
         },
         cancel(reason) {
             nodeStream.pause();
-        }
+		},
+		type: "bytes"
     });
 }
 
@@ -92,7 +100,7 @@ export function createReadableStream(instance) {
 				// TODO: Should we only do Buffer.from() if chunk is a UInt8Array?
 				// Potentially it makes more sense for down-stream consumers of fetch to cast to Buffer, instead?
 				// if(isUInt8Array(chunk)) {
-				controller.enqueue(Buffer.from(chunk))
+				controller.enqueue(new Uint8Array(Buffer.from(chunk)));
 			}
 		}));
 	}
@@ -107,46 +115,47 @@ export function createReadableStream(instance) {
 			switch (bodyType) {
 				case "String":
 					// body is a string:
-					controller.enqueue(Buffer.from(body));
+					controller.enqueue(new Uint8Array(Buffer.from(body)));
 					controller.close();
 					break;
 				case "URLSearchParams":
 					// body is a URLSearchParams
-					controller.enqueue(Buffer.from(body.toString()));
+					controller.enqueue(new Uint8Array(Buffer.from(body.toString())));
 					controller.close();
 					break;
 				case "Blob":
 					// body is blob
-					controller.enqueue(Buffer.from(body[BUFFER]));
+					controller.enqueue(new Uint8Array(Buffer.from(body[BUFFER])));
 					controller.close();
 					break;
 				case "Buffer":
 					// body is Buffer
-					controller.enqueue(Buffer.from(body))
+					controller.enqueue(new Uint8Array(Buffer.from(body)));
 					controller.close();
 					break;
 				case "ArrayBuffer":
 					// body is ArrayBuffer
-					controller.enqueue(Buffer.from(body))
+					controller.enqueue(new Uint8Array(Buffer.from(body)));
 					controller.close();
 					break;
 				case "ArrayBufferView":
 					// body is ArrayBufferView
-					controller.enqueue(Buffer.from(body.buffer))
+					controller.enqueue(new Uint8Array(Buffer.from(body.buffer)));
 					controller.close();
 					break;
 				case "FormData":
-					controller.enqueue(Buffer.from(body.toString()));
+					controller.enqueue(new Uint8Array(Buffer.from(body.toString())));
 					controller.close();
 					break;
 				case "other":
-					controller.enqueue(Buffer.from(String(body)));
+					controller.enqueue(new Uint8Array(Buffer.from(String(body))));
 					controller.close();
 					break;
 				default:
 					throw new Error("createReadableStream received an instance body that getTypeOfBody could not understand");
 			}
-		}
+		},
+		type: "bytes"
 	});
 
 	return readable;

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ import resumer from "resumer";
 import FormData from "form-data";
 import stringToArrayBuffer from "string-to-arraybuffer";
 import URLSearchParams_Polyfill from "url-search-params";
-import { ReadableStream } from "web-streams-polyfill";
+import { ReadableStream } from "@mattiasbuelens/web-streams-polyfill/ponyfill/es6";
 import { URL } from "whatwg-url";
 
 const { spawn } = require("child_process");


### PR DESCRIPTION
This PR adds support for BYOB ReadbleStreams by using the "bytes" type of underyling source. See [the docs](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/ReadableStream) for more info. 