### PR TITLE
Add Blob.arrayBuffer and Blob.text methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
     "babel-plugin-istanbul": "^4.1.5",
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.16.3",
-    "chai": "^3.5.0",
+    "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "chai-iterator": "^1.1.1",
-    "chai-string": "^1.3.0",
+    "chai-iterator": "^3.0.2",
+    "chai-string": "^1.5.0",
     "codecov": "^3.0.0",
     "cross-env": "^5.1.3",
     "form-data": "^2.3.1",
@@ -61,10 +61,10 @@
   },
   "dependencies": {
     "@mattiasbuelens/web-streams-polyfill": "^0.3.2",
-    "busboy": "^0.3.0",
-    "formdata-node": "^1.5.1"
+    "busboy": "^0.3.1",
+    "formdata-node": "^2.4.0"
   },
   "peerDependencies": {
-    "form-data": ">= 2.1.0"
+    "form-data": ">=3.0.0"
   }
 }

--- a/src/blob.js
+++ b/src/blob.js
@@ -1,8 +1,10 @@
 // Based on https://github.com/tmpvar/jsdom/blob/aa85b2abf07766ff7bf5c1f6daafb3726f2f2db5/lib/jsdom/living/blob.js
 // (MIT licensed)
+import { TextDecoder } from 'util'
 
 export const BUFFER = Symbol('buffer');
 const TYPE = Symbol('type');
+const decoder = new TextDecoder('utf-8')
 
 export default class Blob {
 	constructor() {
@@ -41,42 +43,30 @@ export default class Blob {
 			this[TYPE] = type;
 		}
 	}
-	get size() {
+	get size () {
 		return this[BUFFER].length;
 	}
-	get type() {
+	get type () {
 		return this[TYPE];
 	}
-	slice() {
+	arrayBuffer (start = 0, end) {
 		const size = this.size;
 
-		const start = arguments[0];
-		const end = arguments[1];
-		let relativeStart, relativeEnd;
-		if (start === undefined) {
-			relativeStart = 0;
-		} else if (start < 0) {
-			relativeStart = Math.max(size + start, 0);
-		} else {
-			relativeStart = Math.min(start, size);
-		}
-		if (end === undefined) {
-			relativeEnd = size;
-		} else if (end < 0) {
-			relativeEnd = Math.max(size + end, 0);
-		} else {
-			relativeEnd = Math.min(end, size);
-		}
-		const span = Math.max(relativeEnd - relativeStart, 0);
+		start = start < 0 ? Math.max(size + start, 0) : (start !== 0 ? Math.min(start, size) : start)
+		end = !end ? size : (size < 0 ? Math.max(size + end, 0) : Math.min(end, size))
 
-		const buffer = this[BUFFER];
-		const slicedBuffer = buffer.slice(
-			relativeStart,
-			relativeStart + span
-		);
+		const span = Math.max(end - start)
+		const buffer = this[BUFFER]
+		return buffer.slice(start, start + span)
+	}
+	slice () {
+		const slicedBuffer = this.arrayBuffer(...arguments)
 		const blob = new Blob([], { type: arguments[2] });
 		blob[BUFFER] = slicedBuffer;
 		return blob;
+	}
+	text () {
+		return decoder.decode(this[BUFFER]).toString()
 	}
 }
 


### PR DESCRIPTION
I needed [Blob.arrayBuffer](https://developer.mozilla.org/en-US/docs/Web/API/Blob/arrayBuffer) and [Blob.text](https://developer.mozilla.org/en-US/docs/Web/API/Blob/text) for an updated version of a CloudFlare Worker tool (forked from  [dollarshaveclub/cloudworker](https://github.com/dollarshaveclub/cloudworker))I'm working on. The arrayBuffer is required to do Brotli de/compression (and other forms of compression) within a cloud worker.

Most of the required code already existed within the existing `Blob.slice` method. I abstracted it into its own function, calling it from within the slice method.

I ran unit tests before and after. An `npm install` flat out fails without updating the chai dependencies. I updated these. Prior to creating any updates, I ran the tests and there were a few errors for code unrelated to the Blob class. Upon completion, I ran the tests again and got the same result, suggesting anything Blob related passed without error.

I tried updating all of the dependencies, but Babel has changed enough that it caused the build to change (particularly the default fetch export). Those changes have obviously not been included in this PR, but I wanted there to be an awareness of them.

I've created a new npm package with these changes for my own purposes (@author.io/node-fetch), which is working well. So, if you choose not to merge this, other folks will know a place where they can still obtain these particular features.